### PR TITLE
feat(ingest): migrate to FastAPI lifespan with structured logging

### DIFF
--- a/services/data-ingest-service/app/main.py
+++ b/services/data-ingest-service/app/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import logging
 import os
+from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -14,6 +16,8 @@ except Exception:  # pragma: no cover - aiokafka missing in some envs
     AIOKafkaProducer = None  # type: ignore
 
 app = FastAPI(title="Data Ingest Service", version="0.3.0")
+
+LOGGER = logging.getLogger("data-ingest-service")
 
 # OpenTelemetry initialization (no-op if not configured via env)
 try:
@@ -54,33 +58,105 @@ AUTH_INTROSPECT_URL = os.getenv(
     "AUTH_INTROSPECT_URL", "http://auth-service:8001/api/auth/introspect"
 )
 
+# Background controls
+INGEST_PUBLISH_ENABLED = os.getenv("INGEST_PUBLISH_ENABLED", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 
-@app.on_event("startup")
-async def on_startup():
+
+def _in_pytest() -> bool:
+    return bool(os.environ.get("PYTEST_CURRENT_TEST"))
+
+
+async def _start_kafka() -> None:
     global producer
+    if not INGEST_PUBLISH_ENABLED:
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "startup",
+                    "component": "kafka_producer",
+                    "enabled": False,
+                    "reason": "INGEST_PUBLISH_ENABLED=false",
+                },
+            )
+        except Exception:
+            pass
+        return
     if AIOKafkaProducer is None:
+        # No kafka lib available; operate in accept-only mode
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "startup",
+                    "component": "kafka_producer",
+                    "enabled": False,
+                    "reason": "aiokafka_missing",
+                },
+            )
+        except Exception:
+            pass
+        return
+    if _in_pytest():
+        # Gate kafka during pytest
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "startup",
+                    "component": "kafka_producer",
+                    "enabled": False,
+                    "reason": "pytest_gating_kafka",
+                },
+            )
+        except Exception:
+            pass
         return
     try:
         loop = asyncio.get_event_loop()
-        producer = AIOKafkaProducer(bootstrap_servers=bootstrap, loop=loop)
-        await producer.start()
+        _producer = AIOKafkaProducer(bootstrap_servers=bootstrap, loop=loop)
+        await _producer.start()
+        producer = _producer
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "startup",
+                    "component": "kafka_producer",
+                    "enabled": True,
+                    "bootstrap": bootstrap,
+                    "topic_default": topic_default,
+                },
+            )
+        except Exception:
+            pass
     except Exception:
         producer = None
 
 
-@app.on_event("shutdown")
-async def on_shutdown():
+async def _stop_kafka() -> None:
     global producer
-    try:
-        if producer is not None:
+    if producer is not None:
+        try:
             await producer.stop()
-    finally:
-        producer = None
-
-    # Stop gRPC server task if present
-    task = _state.get("grpc_task")
-    if task is not None:
-        task.cancel()
+        except Exception:
+            pass
+        finally:
+            producer = None
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "shutdown",
+                    "component": "kafka_producer",
+                },
+            )
+        except Exception:
+            pass
 
 
 async def _check_auth(headers: Dict[str, str]) -> None:
@@ -102,6 +178,11 @@ async def _check_auth(headers: Dict[str, str]) -> None:
     except Exception:
         # Fail closed when auth is required
         raise HTTPException(status_code=401, detail="auth failure")
+
+
+@app.get("/producer/status")
+async def producer_status() -> Dict[str, bool]:
+    return {"running": bool(producer is not None)}
 
 
 @app.post("/ingest")
@@ -211,15 +292,90 @@ async def _grpc_handler_send(device_id: str, kind: str, data_json: str):
     return True, sent, None
 
 
-@app.on_event("startup")
-async def _maybe_start_grpc():
+async def _start_grpc() -> None:
     # Defer import to runtime
     try:
         from .grpc_server import INGEST_ENABLED, serve  # type: ignore
 
         if INGEST_ENABLED:
+            if _in_pytest():
+                # avoid running grpc server within pytest
+                try:
+                    LOGGER.info(
+                        "Service lifecycle event",
+                        extra={
+                            "event": "startup",
+                            "component": "grpc_server",
+                            "enabled": False,
+                            "reason": "pytest_gating_grpc",
+                        },
+                    )
+                except Exception:
+                    pass
+                return
             task = asyncio.create_task(serve(_grpc_handler_send))
             _state["grpc_task"] = task
+            try:
+                LOGGER.info(
+                    "Service lifecycle event",
+                    extra={
+                        "event": "startup",
+                        "component": "grpc_server",
+                        "enabled": True,
+                    },
+                )
+            except Exception:
+                pass
     except Exception:
         # If grpc server cannot start, continue HTTP service
-        pass
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "startup",
+                    "component": "grpc_server",
+                    "enabled": False,
+                    "reason": "grpc_start_failed",
+                },
+            )
+        except Exception:
+            pass
+
+
+async def _stop_grpc() -> None:
+    task = _state.get("grpc_task")
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except Exception:
+            pass
+        finally:
+            _state["grpc_task"] = None
+        try:
+            LOGGER.info(
+                "Service lifecycle event",
+                extra={
+                    "event": "shutdown",
+                    "component": "grpc_server",
+                },
+            )
+        except Exception:
+            pass
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    # Startup
+    await _start_kafka()
+    await _start_grpc()
+    try:
+        yield
+    finally:
+        # Shutdown
+        await _stop_grpc()
+        await _stop_kafka()
+
+
+# Attach lifespan to app
+app.router.lifespan_context = lifespan

--- a/services/data-ingest-service/tests/conftest.py
+++ b/services/data-ingest-service/tests/conftest.py
@@ -1,0 +1,29 @@
+# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+# Insert service root first so local `app` is resolved
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+# Also add repo root for shared libs fallback
+REPO_ROOT = SERVICE_ROOT.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+# Force module alias `app` to point to service-local package
+try:
+    import importlib
+
+    spec = importlib.util.spec_from_file_location(
+        "app",
+        SERVICE_ROOT.joinpath("app", "__init__.py"),
+    )
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("app", module)
+        spec.loader.exec_module(module)
+except Exception:
+    # tests will fail if imports cannot be resolved; keep silent here
+    pass

--- a/services/data-ingest-service/tests/test_lifespan.py
+++ b/services/data-ingest-service/tests/test_lifespan.py
@@ -1,0 +1,31 @@
+# ruff: noqa: E402
+import os
+
+import httpx
+import pytest
+
+try:
+    from asgi_lifespan import LifespanManager  # type: ignore
+except Exception:  # pragma: no cover
+    LifespanManager = None  # type: ignore
+
+# Ensure pytest gating is detected
+os.environ.setdefault("PYTEST_CURRENT_TEST", "1")
+
+from app.main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_producer_gated_during_pytest():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        if LifespanManager is not None:
+            async with LifespanManager(app):
+                r = await ac.get("/producer/status")
+        else:
+            r = await ac.get("/producer/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data.get("running"), bool)
+    # During pytest, background kafka should not be running
+    assert data.get("running") is False

--- a/services/data-ingest-service/tests/test_ws_ingest.py
+++ b/services/data-ingest-service/tests/test_ws_ingest.py
@@ -1,6 +1,5 @@
+from app.main import app
 from fastapi.testclient import TestClient
-
-from services.data-ingest-service.app.main import app  # type: ignore
 
 
 def test_ws_ingest_accepts_and_replies():


### PR DESCRIPTION
Migrates data-ingest-service to FastAPI lifespan with pytest gating for Kafka and gRPC. Adds /producer/status endpoint and tests.